### PR TITLE
feat: export formatNumbers pipe

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
 export { NgxLocalizedNumbers } from "./src/localized-numbers.module";
 export { LocalizationFormatCurrencyPipe } from "./src/format-currency.pipe";
+export { LocalizationFormatNumberPipe } from "./src/format-number.pipe";
 export { NgxLocalizedNumbersService } from "./src/localized-numbers.service";


### PR DESCRIPTION
I had problems using the `formatNumber` pipe as described in the README. The `formatCurrency` was available. 